### PR TITLE
Workaround for "0.00 ms" ping on certain servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ wcversion*
 cpucount
 src/lib
 src/include
+src/sauer_client
+src/wc_chat_server
+bin_unix

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1185,7 +1185,7 @@ namespace game
             if(!d) return;
         }
         float ping = d->highresping ? d->highresping : (float)d->ping;
-        draw_textf("%.2f ms", w-10*fonth, h-fonth*3/2, ping);
+        draw_textf(d->highresping ? "%.2f ms" : "%.0f ms", w-10*fonth, h-fonth*3/2, ping);
         increasedisplaycount();
     }
 

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -574,7 +574,7 @@ namespace game
     ICOMMAND(gettotaldamage, "s", (const char *cn), fpsent *o = getclient(cn); if(!o) o = player1; intret(o->totaldamage));
     ICOMMAND(gettotalshots, "s", (const char *cn), fpsent *o = getclient(cn); if(!o) o = player1; intret(o->totalshots));
     ICOMMAND(getping, "s", (const char *cn), fpsent *o = getclient(cn); if(!o) o = player1; intret(o->ping)); //NEW
-    ICOMMAND(getfloatping, "s", (const char *cn), fpsent *o = getclient(cn); if(!o) o = player1; floatret(o->highresping)); //NEW
+    ICOMMAND(getfloatping, "s", (const char *cn), fpsent *o = getclient(cn); if(!o) o = player1; floatret(o->highresping ? o->highresping : (float)o->ping)); //NEW
     ICOMMAND(gethudclientnum, "", (), intret(hudplayer()->clientnum)); //NEW
 
     vector<fpsent *> clients;
@@ -1184,7 +1184,7 @@ namespace game
             d = getclient(d->ownernum);
             if(!d) return;
         }
-        float ping = d->highresping;
+        float ping = d->highresping ? d->highresping : (float)d->ping;
         draw_textf("%.2f ms", w-10*fonth, h-fonth*3/2, ping);
         increasedisplaycount();
     }

--- a/src/mod/gamemod.cpp
+++ b/src/mod/gamemod.cpp
@@ -133,7 +133,7 @@ namespace gamemod
             {
                 if (d == player1)
                 {
-                    str.fmt("%.2f", d->highresping);
+                    str.fmt("%.2f", d->highresping ? d->highresping : (float)d->ping);
                     break;
                 }
             }


### PR DESCRIPTION
Closes #14 
Replace `highresping` with regular ping on servers where the former is not available.