### PR TITLE
Scoreboard: show CTF flag icons

### DIFF
--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -124,6 +124,20 @@ namespace game
     collectclientmode collectmode;
 
     //NEW
+    // checks if a player is carrying the flag
+    // 0 => no flag; 1 => team good or neutral (m_hold); 2 => team evil
+    int hasflag(fpsent *d) {
+        if(!m_ctf) return 0;
+        loopv(ctfmode.flags) {
+            if(ctfmode.flags[i].owner == d) {
+                return m_hold ? 1 : ctfmode.flags[i].team;
+            }
+        }
+        return 0;
+    }
+    //NEW END
+
+    //NEW
     void demorecorder_initflags(ucharbuf &p)
     {
         if(cmode != &ctfmode) return;

--- a/src/fpsgame/game.h
+++ b/src/fpsgame/game.h
@@ -814,6 +814,7 @@ namespace game
     extern void forceintermission();
     extern void c2sinfo(bool force = false);
     extern void sendposition(fpsent *d, bool reliable = false);
+    extern int hasflag(fpsent *d); //NEW
 
     // monster
     struct monster;

--- a/src/fpsgame/scoreboard.cpp
+++ b/src/fpsgame/scoreboard.cpp
@@ -26,6 +26,7 @@ namespace game
     MODVARP(showacc, 0, 1, 1);
     MODVARP(showtks, 0, 0, 1);
     MODVARP(showcountry, 0, 3, 5);
+    MODVARP(showctfflagicons, 0, 1, 1);
     MODVARP(showserveruptime, 0, 0, 1);
     MODVARP(showservermod, 0, 0, 1);
     MODVARP(oldscoreboard, 0, 0, 1);
@@ -495,6 +496,30 @@ namespace game
             }
 
             if(oldscoreboard) goto next; //NEW
+
+            //NEW
+            // show flag icon next to player's name
+            if(m_ctf && showctfflagicons) {
+                g.pushlist();
+                g.text("", 0x000000);
+                loopscoregroup(o, {
+                    // check if the player is carrying a flag
+                    int flagteam = hasflag(o);
+                    if(flagteam > 0) { // has flag
+                        // choose the correct icon
+                        const char *icon =
+                            m_hold ? "../hud/blip_neutral_flag.png"
+                            : isteam(player1->team, flagteam == 1 ? "good" : "evil") ? "../hud/blip_blue_flag.png" : "../hud/blip_red_flag.png";
+                        
+                        g.text("", 0x000000, icon);
+                    } else {
+                        g.text("", 0x000000);
+                    }
+                });
+                g.poplist();
+            }
+            //NEW END
+
             name:; //NEW
 
             if(oldscoreboard) g.space(6); //NEW


### PR DESCRIPTION
Shows flag icons next to the name of players holding the flag, also shows the flag's team color.

This is especially useful in custom game modes where players can steal both flags, as it can be hard to keep track of who is holding each flag.

Added config var (int):
- showctfflagicons (0, 1, 1): enables/disables CTF flag icons in the scoreboard